### PR TITLE
ci: don't run workflows twice when coming from local branches

### DIFF
--- a/.github/workflows/accuracy.yml
+++ b/.github/workflows/accuracy.yml
@@ -1,6 +1,11 @@
 name: Accuracy
 
-on: [push, pull_request_target, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+  pull_request_target:
+  workflow_dispatch:
 
 jobs:
   linux:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: Build
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   windows:


### PR DESCRIPTION
If we don't limit `push` to `master`, any repo-local branch will cause
each job in CI to run twice, as can be seen here: https://github.com/hades-emu/Hades/pull/69
