### PR TITLE
Revamp the video effects options

### DIFF
--- a/include/app/app.h
+++ b/include/app/app.h
@@ -38,6 +38,26 @@ enum texture_filter_kind {
     TEXTURE_FILTER_MAX = 1,
 };
 
+enum pixel_color_effect_kind {
+    PIXEL_COLOR_EFFECT_MIN = 0,
+
+    PIXEL_COLOR_EFFECT_NONE = 0,
+    PIXEL_COLOR_EFFECT_COLOR_CORRECTION = 1,
+    PIXEL_COLOR_EFFECT_GREY_SCALE = 2,
+
+    PIXEL_COLOR_EFFECT_MAX = 2,
+};
+
+enum pixel_scaler_effect_kind {
+    PIXEL_SCALER_EFFECT_MIN = 0,
+
+    PIXEL_SCALER_EFFECT_NONE = 0,
+    PIXEL_SCALER_EFFECT_LCD_GRID = 1,
+    PIXEL_SCALER_EFFECT_LCD_GRID_WITH_RGB_STRIPES = 2,
+
+    PIXEL_SCALER_EFFECT_MAX = 2,
+};
+
 enum aspect_ratio {
     ASPECT_RATIO_MIN = 0,
 
@@ -179,19 +199,24 @@ struct app {
     struct {
         SDL_GLContext gl_context;
 
-        enum texture_filter_kind texture_filter;
-        GLuint game_texture_in;
-        GLuint game_texture_a;
-        GLuint game_texture_b;
+        GLuint game_texture;
+        GLuint pixel_color_texture;
+        GLuint pixel_scaler_texture;
         GLuint fbo;
         GLuint vao;
         GLuint vbo;
 
         GLuint program_color_correction;
+        GLuint program_grey_scale;
         GLuint program_lcd_grid;
+        GLuint program_lcd_grid_with_rgb_stripes;
 
-        GLuint active_programs[MAX_GFX_PROGRAMS];
-        size_t active_programs_length;
+        GLuint pixel_color_program;
+        bool use_pixel_color_program;
+
+        GLuint pixel_scaler_program;
+        size_t pixel_scaler_size;
+        bool use_pixel_scaler_program;
     } gfx;
 
     struct {
@@ -214,8 +239,9 @@ struct app {
         uint32_t display_size;
         enum aspect_ratio aspect_ratio;
         bool vsync;
-        bool color_correction;
-        bool lcd_grid;
+        enum texture_filter_kind texture_filter;
+        enum pixel_color_effect_kind pixel_color_effect;
+        enum pixel_scaler_effect_kind pixel_scaler_effect;
     } video;
 
     struct {
@@ -343,6 +369,15 @@ void app_sdl_video_rebuild_pipeline(struct app *app);
 
 /* app/shaders/frag-color-correction.c */
 extern char const *SHADER_FRAG_COLOR_CORRECTION;
+
+/* app/shaders/frag-gameboy.c */
+extern char const *SHADER_FRAG_GAMEBOY;
+
+/* app/shaders/frag-grey-scale.c */
+extern char const *SHADER_FRAG_GREY_SCALE;
+
+/* app/shaders/frag-lcd-grid-with-rgb-stripes.c */
+extern char const *SHADER_FRAG_LCD_GRID_WITH_RGB_STRIPES;
 
 /* app/shaders/frag-lcd-grid.c */
 extern char const *SHADER_FRAG_LCD_GRID;

--- a/source/app/config.c
+++ b/source/app/config.c
@@ -115,17 +115,19 @@ app_config_load(
             app->video.vsync = b;
         }
 
-        if (mjson_get_bool(data, data_len, "$.video.color_correction", &b)) {
-            app->video.color_correction = b;
-        }
-
-        if (mjson_get_bool(data, data_len, "$.video.lcd_grid", &b)) {
-            app->video.lcd_grid = b;
-        }
-
         if (mjson_get_number(data, data_len, "$.video.texture_filter", &d)) {
-            app->gfx.texture_filter = (int)d;
-            app->gfx.texture_filter = max(TEXTURE_FILTER_MIN, min(app->gfx.texture_filter, TEXTURE_FILTER_MAX));
+            app->video.texture_filter = (int)d;
+            app->video.texture_filter = max(TEXTURE_FILTER_MIN, min(app->video.texture_filter, TEXTURE_FILTER_MAX));
+        }
+
+        if (mjson_get_number(data, data_len, "$.video.pixel_color_effect", &d)) {
+            app->video.pixel_color_effect = (int)d;
+            app->video.pixel_color_effect = max(PIXEL_COLOR_EFFECT_MIN, min(app->video.pixel_color_effect, PIXEL_COLOR_EFFECT_MAX));
+        }
+
+        if (mjson_get_number(data, data_len, "$.video.pixel_scaler_effect", &d)) {
+            app->video.pixel_scaler_effect = (int)d;
+            app->video.pixel_scaler_effect = max(PIXEL_SCALER_EFFECT_MIN, min(app->video.pixel_scaler_effect, PIXEL_SCALER_EFFECT_MAX));
         }
     }
 
@@ -233,9 +235,9 @@ app_config_save(
                 "display_size": %d,
                 "aspect_ratio": %d,
                 "vsync": %B,
-                "color_correction": %B,
-                "lcd_grid": %B,
-                "texture_filter": %d
+                "texture_filter": %d,
+                "pixel_color_effect": %d,
+                "pixel_scaler_effect": %d
             },
 
             // Audio
@@ -260,9 +262,9 @@ app_config_save(
         (int)app->video.display_size,
         (int)app->video.aspect_ratio,
         (int)app->video.vsync,
-        (int)app->video.color_correction,
-        (int)app->video.lcd_grid,
-        (int)app->gfx.texture_filter,
+        (int)app->video.texture_filter,
+        (int)app->video.pixel_color_effect,
+        (int)app->video.pixel_scaler_effect,
         (int)app->audio.mute,
         app->audio.level
     );

--- a/source/app/main.c
+++ b/source/app/main.c
@@ -68,14 +68,14 @@ main(
     app.emulation.rtc.autodetect = true;
     app.emulation.rtc.enabled = true;
     app.file.bios_path = strdup("./bios.bin");
-    app.video.color_correction = true;
+    app.video.pixel_color_effect = PIXEL_COLOR_EFFECT_COLOR_CORRECTION;
     app.video.vsync = false;
     app.video.display_size = 3;
     app.video.aspect_ratio = ASPECT_RATIO_RESIZE;
     app.audio.mute = false;
     app.audio.level = 1.0f;
     app.audio.resample_frequency = 48000;
-    app.gfx.texture_filter = TEXTURE_FILTER_NEAREST;
+    app.video.texture_filter = TEXTURE_FILTER_NEAREST;
     app.ui.win.resize = true;
     app.ui.win.resize_with_ratio = false;
 

--- a/source/app/meson.build
+++ b/source/app/meson.build
@@ -66,6 +66,8 @@ libapp = static_library(
     'sdl/init.c',
     'sdl/video.c',
     'shaders/frag-color-correction.c',
+    'shaders/frag-grey-scale.c',
+    'shaders/frag-lcd-grid-with-rgb-stripes.c',
     'shaders/frag-lcd-grid.c',
     'shaders/vertex-common.c',
     'windows/game.c',

--- a/source/app/shaders/frag-grey-scale.c
+++ b/source/app/shaders/frag-grey-scale.c
@@ -10,9 +10,9 @@
 #include "app/app.h"
 
 /*
-** LCD Grid effect.
+** Grey-Scale effect.
 */
-char const *SHADER_FRAG_LCD_GRID = GLSL(
+char const *SHADER_FRAG_GREY_SCALE = GLSL(
     layout(location = 0) out vec4 frag_color;
 
     in vec2 v_uv;
@@ -21,16 +21,7 @@ char const *SHADER_FRAG_LCD_GRID = GLSL(
 
     void main() {
         vec4 color = texture(u_screen_map, v_uv);
-        vec4 lcd = vec4(1.0);
-
-        int offset_x = int(mod(gl_FragCoord.x, 3.0));
-        int offset_y = int(mod(gl_FragCoord.y, 3.0));
-
-        if (offset_x == 0 || offset_y == 0) {
-            lcd = vec4(0.8);
-        }
-
-        frag_color = color * lcd;
-        frag_color.a = 1.0f;
+        float avg = (color.r + color.g + color.b) / 3.0;
+        frag_color = vec4(avg, avg, avg, 1.0);
     }
 );

--- a/source/app/shaders/frag-lcd-grid-with-rgb-stripes.c
+++ b/source/app/shaders/frag-lcd-grid-with-rgb-stripes.c
@@ -10,9 +10,9 @@
 #include "app/app.h"
 
 /*
-** LCD Grid effect.
+** LCD Grid effect with visible red/green/blue stripes for each pixels.
 */
-char const *SHADER_FRAG_LCD_GRID = GLSL(
+char const *SHADER_FRAG_LCD_GRID_WITH_RGB_STRIPES = GLSL(
     layout(location = 0) out vec4 frag_color;
 
     in vec2 v_uv;
@@ -21,12 +21,20 @@ char const *SHADER_FRAG_LCD_GRID = GLSL(
 
     void main() {
         vec4 color = texture(u_screen_map, v_uv);
-        vec4 lcd = vec4(1.0);
+        vec4 lcd = vec4(0.8);
 
         int offset_x = int(mod(gl_FragCoord.x, 3.0));
         int offset_y = int(mod(gl_FragCoord.y, 3.0));
 
-        if (offset_x == 0 || offset_y == 0) {
+        if (offset_x == 0) {
+            lcd.r = 1.0f;
+        } else if (offset_x == 1) {
+            lcd.g = 1.0f;
+        } else if (offset_x == 2) {
+            lcd.b = 1.0f;
+        }
+
+        if (offset_y == 0) {
             lcd = vec4(0.8);
         }
 

--- a/source/app/windows/menubar.c
+++ b/source/app/windows/menubar.c
@@ -321,29 +321,61 @@ app_win_menubar_video(
 
         /* Texture Filter */
         if (igBeginMenu("Texture Filter", true)) {
-            if (igMenuItem_Bool("Nearest", NULL, app->gfx.texture_filter == TEXTURE_FILTER_NEAREST, true)) {
-                app->gfx.texture_filter = TEXTURE_FILTER_NEAREST;
+            if (igMenuItem_Bool("Nearest", NULL, app->video.texture_filter == TEXTURE_FILTER_NEAREST, true)) {
+                app->video.texture_filter = TEXTURE_FILTER_NEAREST;
                 app_sdl_video_rebuild_pipeline(app);
             }
 
-            if (igMenuItem_Bool("Linear", NULL, app->gfx.texture_filter == TEXTURE_FILTER_LINEAR, true)) {
-                app->gfx.texture_filter = TEXTURE_FILTER_LINEAR;
+            if (igMenuItem_Bool("Linear", NULL, app->video.texture_filter == TEXTURE_FILTER_LINEAR, true)) {
+                app->video.texture_filter = TEXTURE_FILTER_LINEAR;
                 app_sdl_video_rebuild_pipeline(app);
             }
 
             igEndMenu();
         }
 
-        /* Color Correction */
-        if (igMenuItem_Bool("Color correction", NULL, app->video.color_correction, true)) {
-            app->video.color_correction ^= 1;
-            app_sdl_video_rebuild_pipeline(app);
+        /* Pixel Color Effect */
+        if (igBeginMenu("Color Effect", true)) {
+            if (igMenuItem_Bool("None", NULL, app->video.pixel_color_effect == PIXEL_COLOR_EFFECT_NONE, true)) {
+                app->video.pixel_color_effect = PIXEL_COLOR_EFFECT_NONE;
+                app_sdl_video_rebuild_pipeline(app);
+            }
+
+            igSeparator();
+
+            if (igMenuItem_Bool("Color Correction", NULL, app->video.pixel_color_effect == PIXEL_COLOR_EFFECT_COLOR_CORRECTION, true)) {
+                app->video.pixel_color_effect = PIXEL_COLOR_EFFECT_COLOR_CORRECTION;
+                app_sdl_video_rebuild_pipeline(app);
+            }
+
+            if (igMenuItem_Bool("Grey Scale", NULL, app->video.pixel_color_effect == PIXEL_COLOR_EFFECT_GREY_SCALE, true)) {
+                app->video.pixel_color_effect = PIXEL_COLOR_EFFECT_GREY_SCALE;
+                app_sdl_video_rebuild_pipeline(app);
+            }
+
+            igEndMenu();
         }
 
-        /* LCD Effect */
-        if (igMenuItem_Bool("LCD Grid Effect", NULL, app->video.lcd_grid, true)) {
-            app->video.lcd_grid ^= 1;
-            app_sdl_video_rebuild_pipeline(app);
+        /* Pixel Scaler Effect */
+        if (igBeginMenu("Scaler Effect", true)) {
+            if (igMenuItem_Bool("None", NULL, app->video.pixel_scaler_effect == PIXEL_SCALER_EFFECT_NONE, true)) {
+                app->video.pixel_scaler_effect = PIXEL_SCALER_EFFECT_NONE;
+                app_sdl_video_rebuild_pipeline(app);
+            }
+
+            igSeparator();
+
+            if (igMenuItem_Bool("LCD Grid /w RGB Stripes", NULL, app->video.pixel_scaler_effect == PIXEL_SCALER_EFFECT_LCD_GRID_WITH_RGB_STRIPES, true)) {
+                app->video.pixel_scaler_effect = PIXEL_SCALER_EFFECT_LCD_GRID_WITH_RGB_STRIPES;
+                app_sdl_video_rebuild_pipeline(app);
+            }
+
+            if (igMenuItem_Bool("LCD Grid", NULL, app->video.pixel_scaler_effect == PIXEL_SCALER_EFFECT_LCD_GRID, true)) {
+                app->video.pixel_scaler_effect = PIXEL_SCALER_EFFECT_LCD_GRID;
+                app_sdl_video_rebuild_pipeline(app);
+            }
+
+            igEndMenu();
         }
 
         /* VSync */


### PR DESCRIPTION
This revamps the video effects option to have a dedicate `Color Effect` and `Scaler Effect` submenu, with the first one with two options: Color Correction and Grey Scale (new) and the 2nd one with two options too: LCD Grid (new) and LCD Grid /w RGB stripes.