### PR TITLE
Prevent a bug with NFDe on Windows by removing the "./" prefix of the default path of each configurable directories.

### DIFF
--- a/source/app/main.c
+++ b/source/app/main.c
@@ -59,11 +59,11 @@ app_settings_default(
     settings->general.window.hide_cursor_when_mouse_inactive = true;
     settings->general.window.hide_pause_overlay = false;
     settings->general.directories.backup.use_dedicated_directory = false;
-    settings->general.directories.backup.path = strdup("./saves/");
+    settings->general.directories.backup.path = strdup("saves/");
     settings->general.directories.quicksave.use_dedicated_directory = false;
-    settings->general.directories.quicksave.path = strdup("./saves/");
+    settings->general.directories.quicksave.path = strdup("saves/");
     settings->general.directories.screenshot.use_system_directory = true;
-    settings->general.directories.screenshot.path = strdup("./screenshots/");
+    settings->general.directories.screenshot.path = strdup("screenshots/");
     settings->emulation.bios_path = strdup("./bios.bin");
     settings->emulation.skip_bios_intro = false;
     settings->emulation.speed = 1.0;


### PR DESCRIPTION
Fix https://github.com/hades-emu/Hades/issues/88